### PR TITLE
fix topic type name 'byte' to 'octet'

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -50,7 +50,7 @@ import sys
 if sys.version_info >= (3, 0):
     type_map = {
     "bool":    ["bool", "boolean"],
-    "int":     ["int8", "byte", "uint8", "char",
+    "int":     ["int8", "octet", "uint8", "char",
                 "int16", "uint16", "int32", "uint32",
                 "int64", "uint64", "float32", "float64"],
     "float":   ["float32", "float64", "double", "float"],
@@ -61,7 +61,7 @@ if sys.version_info >= (3, 0):
 else:
     type_map = {
     "bool":    ["bool"],
-    "int":     ["int8", "byte", "uint8", "char",
+    "int":     ["int8", "octet", "uint8", "char",
                 "int16", "uint16", "int32", "uint32",
                 "int64", "uint64", "float32", "float64"],
     "float":   ["float32", "float64"],
@@ -74,7 +74,7 @@ else:
 
 list_types = [list, tuple, np.ndarray, array.array]
 ros_time_types = ["builtin_interfaces/Time", "builtin_interfaces/Duration"]
-ros_primitive_types = ["bool", "boolean", "byte", "char", "int8", "uint8", "int16",
+ros_primitive_types = ["bool", "boolean", "octet", "char", "int8", "uint8", "int16",
                        "uint16", "int32", "uint32", "int64", "uint64",
                        "float32", "float64", "float", "double", "string"]
 ros_header_types = ["Header", "std_msgs/Header", "roslib/Header"]


### PR DESCRIPTION
Supports Byte type message.

# How to test
Terminal 1:
```
ros2 topic pub /test_topic std_msgs/msg/Byte
```

Terminal 2: 
```
ros2 run rosbridge_server rosbridge_websocket
```

Terminal 3:
```
python3 topic.py
```

where topic.py is
```
import roslibpy
import time
def callback1(data):
    print("subscribed")
ros = roslibpy.Ros(host='localhost', port=9090)
ros.run()
topic1 = roslibpy.Topic(ros, "/test_topic","std_msgs/msg/Byte")
topic1.subscribe(callback1)
while True:
    time.sleep(1)
```