### PR TITLE
thread implementation

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -119,12 +119,7 @@ def call_service(node_handle, service, args=None):
 
     client = node_handle.create_client(service_class, service)
 
-    future = client.call_async(inst)
-    spin_until_future_complete(node_handle, future)
-    if future.result() is not None:
-        # Turn the response into JSON and pass to the callback
-        json_response = extract_values(future.result())
-    else:
-        raise Exception(future.exception())
+    response = client.call(inst)
+    json_response = extract_values(response)
 
     return json_response

--- a/rosbridge_server/src/rosbridge_server/websocket_handler.py
+++ b/rosbridge_server/src/rosbridge_server/websocket_handler.py
@@ -86,7 +86,7 @@ class RosbridgeWebSocket(WebSocketHandler):
     unregister_timeout = 10.0               # seconds
     bson_only_mode = False
     node_handle = None
-
+    io_loop_instance = None
 
     @log_exceptions
     def open(self):
@@ -189,7 +189,7 @@ class RosbridgeWebSocket(WebSocketHandler):
             binary = False
 
         with self._write_lock:
-            IOLoop.instance().add_callback(partial(self.prewrite_message, message, binary))
+            self.io_loop_instance.add_callback(partial(self.prewrite_message, message, binary))
 
     @coroutine
     def prewrite_message(self, message, binary):


### PR DESCRIPTION
# Bug Fix
This fixes service advertisement and service calls for rosbridge.
There were issues regarding thread assignment to ROS service and communication over websocket.
This solves it by using threading module of python to solve this, but it might be worth trying Autobahn when we create PR to upstream.

# How to test:

## Terminal1:
```
ros2 run rosbridge_server rosbridge_websocket
```

## Terminal2:
```
python3 service_ros2.py
```
where service_ros2.py is:
```
import roslibpy
import time

def handler(request, response):
    print('Setting speed to {}'.format(request['data']))
    response['success'] = True
    return True

ros = roslibpy.Ros(host='localhost', port=9090)
ros.run()

service = roslibpy.Service(ros, '/foo/bar', 'std_srvs/srv/SetBool')
service.advertise(handler)

while True:
    time.sleep(1)
```

## Terminal 3:
```
ros2 service call /foo/bar std_srvs/srv/SetBool "{data: false}"
```

Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>