### PR TITLE
fix byte publishing

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
+++ b/rosbridge_library/src/rosbridge_library/internal/message_conversion.py
@@ -173,7 +173,7 @@ def _from_inst(inst, rostype):
     for binary_type, expression in ros_binary_types_list_braces:
         if expression.sub(binary_type, rostype) in ros_binary_types:
             encoded = get_encoder()(inst)
-            return encoded if python2 else encoded.decode('ascii')
+            return encoded if python2 else inst
 
     # Check for time or duration
     if rostype in ros_time_types:


### PR DESCRIPTION
The bug with publishing byte type was introduced with https://github.com/tier4/rosbridge_suite/pull/3.
With this PR, both publishing and subscribing of byte type should be supported.

# How to test
## Terminal 1:
`ros2 run rosbridge_server rosbridge_websocket`

## Terminal2:
`python3 pub_sub_byte.py`

where pub_sub_byte.py is
```
import roslibpy
import time
import base64

def callback1(data):
    print(data)

ros = roslibpy.Ros(host='localhost', port=9090)
ros.run()

topic = roslibpy.Topic(ros, "/foo/bar", "diagnostic_msgs/msg/DiagnosticStatus")
level = 2
msg = {"level": level, "name": "hoge", "message": "fuga", "hardware_id": "piyo", "values": []}

topic.subscribe(callback1)

while True:
    topic.publish(roslibpy.Message(msg))
    time.sleep(1)
```

# Terminal 3:
Make sure that the topic can be also seen by ros2
`ros2 topic echo /foo/bar`