### PR TITLE
Fix qos_profile for transient_local

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -100,12 +100,9 @@ class MultiSubscriber():
         # Get publishers info
         publishers_info = node_handle.get_publishers_info_by_topic(topic)
 
-        # If it's not established, exception
-        if not publishers_info:
-            raise TopicNotEstablishedException(topic)
-
-        # Use publisher's QoS profile
-        qos_profile = publishers_info[0].qos_profile
+        # Select QoS
+        default_qos_profile = 10
+        qos_profile = publishers_info[0].qos_profile if publishers_info else default_qos_profile
 
         # Create the subscriber and associated member variables
         # Subscriptions is initialized with the current client to start with.

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -97,6 +97,10 @@ class MultiSubscriber():
         if topic_type is not None and topic_type != msg_type_string:
             raise TypeConflictException(topic, topic_type, msg_type_string)
 
+        # Select QoS profile
+        # TODO(tier4): some error handlings?
+        qos_profile = node_handle.get_publishers_info_by_topic(topic)[0].qos_profile
+
         # Create the subscriber and associated member variables
         # Subscriptions is initialized with the current client to start with.
         self.subscriptions = {client_id: callback}
@@ -104,8 +108,7 @@ class MultiSubscriber():
         self.topic = topic
         self.msg_class = msg_class
         self.node_handle = node_handle
-        # TODO(@jubeira): add support for other QoS.
-        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, 10)
+        self.subscriber = node_handle.create_subscription(msg_class, topic, self.callback, qos_profile)
         self.new_subscriber = None
         self.new_subscriptions = {}
 

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -97,9 +97,15 @@ class MultiSubscriber():
         if topic_type is not None and topic_type != msg_type_string:
             raise TypeConflictException(topic, topic_type, msg_type_string)
 
-        # Select QoS profile
-        # TODO(tier4): some error handlings?
-        qos_profile = node_handle.get_publishers_info_by_topic(topic)[0].qos_profile
+        # Get publishers info
+        publishers_info = node_handle.get_publishers_info_by_topic(topic)
+
+        # If it's not established, exception
+        if not publishers_info:
+            raise TopicNotEstablishedException(topic)
+
+        # Use publisher's QoS profile
+        qos_profile = publishers_info[0].qos_profile
 
         # Create the subscriber and associated member variables
         # Subscriptions is initialized with the current client to start with.


### PR DESCRIPTION
Note: not tested well yet.

## How to test

**terminal 1**

```sh
$ ros2 run rosbridge_server rosbridge_websocket
registered capabilities (classes):
 - <class 'rosbridge_library.capabilities.call_service.CallService'>
 - <class 'rosbridge_library.capabilities.advertise.Advertise'>
 - <class 'rosbridge_library.capabilities.publish.Publish'>
 - <class 'rosbridge_library.capabilities.subscribe.Subscribe'>
 - <class 'rosbridge_library.capabilities.defragmentation.Defragment'>
 - <class 'rosbridge_library.capabilities.advertise_service.AdvertiseService'>
 - <class 'rosbridge_library.capabilities.service_response.ServiceResponse'>
 - <class 'rosbridge_library.capabilities.unadvertise_service.UnadvertiseService'>
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/node.py:434: UserWarning: when declaring parmater named 'certfile', declaring a parameter only providing its name is deprecated. You have to either:
	- Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
	- Pass a name and a parameter type.
	- Pass a name and a descriptor with `dynamic_typing=True
  warnings.warn(
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/node.py:434: UserWarning: when declaring parmater named 'keyfile', declaring a parameter only providing its name is deprecated. You have to either:
	- Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
	- Pass a name and a parameter type.
	- Pass a name and a descriptor with `dynamic_typing=True
  warnings.warn(
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
  warnings.warn(
[INFO 1631640752.781774171] [rosbridge_websocket]: Rosbridge WebSocket server started on port 9090
[INFO 1631640752.782510251] [thread_manager]: ros thread started
[INFO 1631640848.652662474] [rosbridge_websocket]: Client connected. 1 clients total.
[INFO 1631640848.675947922] [rosbridge_websocket]: [Client 0] Subscribed to /transient_local
[INFO 1631640848.676682992] [rosbridge_websocket]: [Client 0] Subscribed to /volatile
[INFO 1631640848.677387811] [rosbridge_websocket]: [Client 0] Subscribed to /best_effort
[WARN 1631640881.932589610] [rosbridge_websocket]: Incompatible QoS in topic '/best_effort' requesting. Reconnect
[INFO 1631640889.817998369] [rosbridge_websocket]: Client disconnected. 0 clients total.
```

**terminal 2**
```sh
$ python run_test.py
data: {'data': 0} # transient_local
data: {'data': 1} # volatile
data: {'data': 1} # volatile
data: {'data': 2} # best_effort
```

**terminal 3**
```sh
$ ros2 topic pub --qos-durability transient_local /transient_local example_interfaces/msg/Int8 data:\ 0 -1 --keep-alive 10000
publisher: beginning loop
publishing #1: example_interfaces.msg.Int8(data=0)
```

**terminal 4**
```sh
$ ros2 topic pub --qos-durability volatile /volatile example_interfaces/msg/Int8 data:\ 1
publisher: beginning loop
publishing #1: example_interfaces.msg.Int8(data=1)

publishing #2: example_interfaces.msg.Int8(data=1)
```

**terminal 5**
```sh
$ ros2 topic pub --qos-reliability best_effort /best_effort example_interfaces/msg/Int8 data:\ 2
publisher: beginning loop
[WARN 1631640881.943689552] [_ros2cli_1859089]: New subscription discovered on topic '/best_effort', requesting incompatible QoS. No messages will be sent to it. Last incompatible policy: RELIABILITY
publishing #1: example_interfaces.msg.Int8(data=2)
```

**run_test.py**
```python
import roslibpy
import time

def callback(data):
    print(f"data: {data}")

ros = roslibpy.Ros(host='localhost', port=9090)
ros.run()

transient_local = roslibpy.Topic(ros, "/transient_local", "example_interfaces/msg/Int8")
transient_local.subscribe(callback)

volatile = roslibpy.Topic(ros, "/volatile", "example_interfaces/msg/Int8")
volatile.subscribe(callback)

best_effort = roslibpy.Topic(ros, "/best_effort", "example_interfaces/msg/Int8")
best_effort.subscribe(callback)

while True:
    time.sleep(1)
```
