### PR TITLE
Test service

### DIFF
--- a/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
+++ b/rosbridge_library/src/rosbridge_library/capabilities/advertise_service.py
@@ -29,7 +29,7 @@ class AdvertisedServiceHandler:
         self.id_counter += 1
         return id
 
-    def handle_request(self, req):
+    def handle_request(self, req, res):
         with self.lock:
             self.active_requests += 1
         # generate a unique ID
@@ -62,9 +62,9 @@ class AdvertisedServiceHandler:
                 )
                 return None
 
-        resp = self.responses[request_id]
+        res = self.responses[request_id]
         del self.responses[request_id]
-        return resp
+        return res
 
     def graceful_shutdown(self, timeout):
         """

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -306,6 +306,11 @@ class RosbridgeWebsocketNode(Node):
                 time.sleep(retry_startup_delay)
 
 
+def spin(rosbridge_websocket_node):
+    print("spin")
+    rclpy.spin_once(rosbridge_websocket_node, timeout_sec=0.01)
+
+
 def main(args=None):
     if args is None:
         args = sys.argv
@@ -313,7 +318,7 @@ def main(args=None):
     rclpy.init(args=args)
     node = RosbridgeWebsocketNode()
 
-    spin_callback = PeriodicCallback(lambda: rclpy.spin_once(node, timeout_sec=0.01), 1)
+    spin_callback = PeriodicCallback(lambda: spin(node), 1000)
     spin_callback.start()
     start_hook()
 


### PR DESCRIPTION
Note: This is a PR for issue description.

## How to test

terminal1 (stop spinning after service is called in terminal3)
```sh
$ ros2 run rosbridge_server rosbridge_websocket
registered capabilities (classes):
 - <class 'rosbridge_library.capabilities.call_service.CallService'>
 - <class 'rosbridge_library.capabilities.advertise.Advertise'>
 - <class 'rosbridge_library.capabilities.publish.Publish'>
 - <class 'rosbridge_library.capabilities.subscribe.Subscribe'>
 - <class 'rosbridge_library.capabilities.defragmentation.Defragment'>
 - <class 'rosbridge_library.capabilities.advertise_service.AdvertiseService'>
 - <class 'rosbridge_library.capabilities.service_response.ServiceResponse'>
 - <class 'rosbridge_library.capabilities.unadvertise_service.UnadvertiseService'>
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/node.py:434: UserWarning: when declaring parmater named 'certfile', declaring a parameter only providing its name is deprecated. You have to either:
	- Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
	- Pass a name and a parameter type.
	- Pass a name and a descriptor with `dynamic_typing=True
  warnings.warn(
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/node.py:434: UserWarning: when declaring parmater named 'keyfile', declaring a parameter only providing its name is deprecated. You have to either:
	- Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
	- Pass a name and a parameter type.
	- Pass a name and a descriptor with `dynamic_typing=True
  warnings.warn(
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
  warnings.warn(
[INFO 1632561330.766648680] [rosbridge_websocket]: Rosbridge WebSocket server started on port 9090
[INFO 1632561331.553434372] [rosbridge_websocket]: Client connected. 1 clients total.
[INFO 1632561331.562082770] [rosbridge_websocket]: [Client 0] Advertised service /test_service.
spin
spin
spin
spin
```

terminal2 (no request received)
```sh
$ curl -sL https://github.com/tier4/rosbridge_suite/raw/add-test-scripts/test_scripts/service_server.py | python
loop
loop
loop
loop
```

terminal3 (no response)
```sh
$ ros2 service call /test_service example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
requester: making request: example_interfaces.srv.AddTwoInts_Request(a=1, b=2)
```