### PR TITLE
fix exception in subscribers.py

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -174,12 +174,17 @@ class MultiSubscriber:
 
         """
         with self.lock:
-            del self.subscriptions[client_id]
+            if client_id in self.subscriptions:
+                del self.subscriptions[client_id]
+            elif client_id in self.new_subscriptions:
+                del self.new_subscriptions[client_id]
+            else:
+                self.node_handle.get_logger().warn("Illegal client_id: {}".format(client_id))
 
     def has_subscribers(self):
         """Return true if there are subscribers"""
         with self.lock:
-            return len(self.subscriptions) != 0
+            return (len(self.subscriptions) != 0 or len(self.new_subscriptions) != 0)
 
     def callback(self, msg, callbacks=None):
         """Callback for incoming messages on the rclpy subscription.


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
In the `MultiSubscriber` class, the client_id and callback data are added to the `new_subscriptions` member variable by the `subscribe` function.
However, if the `unsubscribe` function is called without accepting messages from the topic, an exception will be thrown when trying to remove it from the `subscriptions` member variable and trying to remove the non-existent client_id data.

When unsubscribing data that is not included in the `subscriptions` member variable, it has been modified to be deleted from the `new_subscriptions` member variable.

Also, it was modified to include the `new_subscriptions` member variable in the check target of the `has_subscribers` function.
If False is returned by the `has_subscribers` function, the `SubscriberManager` class will delete the object, so if the client ID remains in the `new_subscriptions` member variable, it must be modified so that it will not be deleted.

<!-- Link relevant GitHub issues -->

**Steps to reproduce**
1. Launch rosbridge_websocket in Autoware environment.
ros2 launch autoware_web_controller autoware_web_controller.launch.xml

2. Open autoware_web_controller in multiple tabs.(about 20 tabs)
http://localhost:8085/autoware_web_controller/index.html

3. Close all autoware_web_controller.

