### PR TITLE
Add respawn to rosbridge_websocket_launch.xml

### DIFF
--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -18,11 +18,12 @@
   <arg name="services_glob" default="" />
   <arg name="params_glob" default="" />
   <arg name="bson_only_mode" default="false" />
+  <arg name="respawn" default="false" />
 
   <arg unless="$(var bson_only_mode)" name="binary_encoder" default="default"/>
 
   <group if="$(var ssl)">
-    <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen">
+    <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen" respawn="$(var respawn)">
       <param name="certfile" value="$(var certfile)" />
       <param name="keyfile" value="$(var keyfile)" />
       <param name="port" value="$(var port)"/>
@@ -40,7 +41,7 @@
     </node>
   </group>
   <group unless="$(var ssl)">
-    <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen">
+    <node name="rosbridge_websocket" pkg="rosbridge_server" exec="rosbridge_websocket" output="screen" respawn="$(var respawn)">
       <param name="port" value="$(var port)"/>
       <param name="address" value="$(var address)"/>
       <param name="retry_startup_delay" value="$(var retry_startup_delay)"/>


### PR DESCRIPTION
https://github.com/tier4/autoware.iv/pull/2354 に関連して、rosbridge_websocket_launch.xml にrespawnを追加しました。
projでフォーク使っているみたいなので、とりあえず先にこちらにPRだしました。本家にも出してみます。

```
$ ros2 launch autoware_launch planning_simulator.launch.xml sensor_model:=aip_x1 vehicle_model:=ymc_golfcart_proto2 map_path:=/media/kosuke55/sandisk_ssd/map/ryuyo/
$ ps aux |grep rosbridge
$ kill 2362697 # rosbridgeのプロセスid
```
その後、rosbridgeが再起動して、autoware_web_controllerからの発進もできることを確認した。