### PR TITLE
Fixed error by changing spin to busy waiting

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/services.py
+++ b/rosbridge_library/src/rosbridge_library/internal/services.py
@@ -30,9 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import time
 from threading import Thread
 
-from rclpy import spin_until_future_complete
 from rclpy.expand_topic_name import expand_topic_name
 from rosbridge_library.internal.message_conversion import (
     extract_values,
@@ -124,7 +124,10 @@ def call_service(node_handle, service, args=None):
     client = node_handle.create_client(service_class, service)
 
     future = client.call_async(inst)
-    spin_until_future_complete(node_handle, future)
+
+    while not future.done():
+        time.sleep(0.001)
+
     if future.result() is not None:
         # Turn the response into JSON and pass to the callback
         json_response = extract_values(future.result())


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Fix
## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->
[Jira ticket](https://tier4.atlassian.net/browse/T4PB-14231)
## Description

When multiple services are called through rosbridge, the error "call_service ValueError: generator already executing" appears

<!-- Describe what this PR changes. -->
Normally only one thread does the spinning, and since the node variables are not thread protected, doing concurrent spins causes errors. The message error itself is generated by rclpy.

## Review Procedure
Use the code blow to reproduce the error. The ros2 branch should generate the errors whereas this pr should be able to finish the tests correctly.

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [pull request guidelines][pull-request-guidelines]
- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/KB4FAE/pages/1748435052
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute


How to test:
Use the following code to reproduce the error

```
import threading
import time

from roslibpy import Ros
from roslibpy import Service
from roslibpy import ServiceRequest
import random


def test():
    ros = Ros('127.0.0.1', 9090)
    ros.run()

    def service_callback(request, response): # This is attended in a separate thread
        #print(request)
        global count
        t = 0.001*random.randint(1,10)
        time.sleep(t)

        return True

    #service_callback(None, None)

    service_name = '/stress_test_service'
    service_type = 'test_msgs/srv/Empty'
    service = Service(ros, service_name, service_type)
    service.advertise(service_callback)
    time.sleep(5)

    threads = [threading.Thread(name=f'client_{id}', target=service_client_thread) for id in range(0,50)]

    [thread.start() for thread in threads]
    [thread.join() for thread in threads]

    print("all joined")

    ros.close()

def service_client_thread():

    ros = Ros('127.0.0.1', 9090)
    service_name = '/stress_test_service'
    service_type = 'test_msgs/srv/Empty'


    client = Service(ros, service_name, service_type)
    
    print(threading.currentThread().getName(), f'Entering')

    for i in range(0,100):
        print(threading.currentThread().getName(), f'Iteration {i}')
        result = client.call(ServiceRequest({}))

    print(threading.currentThread().getName(), f'Exiting')


if __name__ == "__main__":
    print("test")
    test()
    print("done")
```